### PR TITLE
Easily include additional packages during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 data/
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN mkdir -p /tmp/so
 RUN cp *.so /tmp/so
 
 FROM ubuntu:18.04
+ARG ADDITIONAL_PACKAGES=""
+ENV ADDITIONAL_PACKAGES=${ADDITIONAL_PACKAGES}
+
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt update && apt -y full-upgrade && apt install -y \
   ca-certificates \
@@ -60,6 +63,7 @@ RUN apt update && apt -y full-upgrade && apt install -y \
   xfce4-xkb-plugin \
   xorgxrdp \
   xrdp \
+  $ADDITIONAL_PACKAGES \
   && \
   rm -rf /var/cache/apt /var/lib/apt/lists && \
   mkdir -p /var/lib/xrdp-pulseaudio-installer

--- a/Readme.md
+++ b/Readme.md
@@ -75,10 +75,14 @@ When bind-mounting `/home/`, make sure it contains a folder `ubuntu/` with prope
 mkdir -p ubuntu
 chown 999:999 ubuntu
 ```
+## Installing additional packages during build
+
+The Dockerfile has support for the build argument ADDITIONAL_PACKAGES to install additional packages during build. Either pass it with `--build-arg` during `docker build` or uncomment the `args` and `ADDITIONAL_PACKAGES` lines in the `docker-compose.yml` and run `docker-compose build`.
 
 ## To run with docker-compose
 ```bash
 git clone https://github.com/danielguerra69/ubuntu-xrdp.git
 cd ubuntu-xrdp/
+cp docker-compose.yml-example docker-compose.yml
 docker-compose up -d
 ```

--- a/docker-compose.yml-example
+++ b/docker-compose.yml-example
@@ -3,6 +3,8 @@ services:
   terminalserver:
     build:
       context: .
+      #args:
+        #ADDITIONAL_PACKAGES: net-tools
     image: danielguerra/ubuntu-xrdp
     container_name: uxrdp
     hostname: terminalserver


### PR DESCRIPTION
I had a discussion with someone about this project who wanted to use it with additionally installed packages and though "hey, you could probably make this easier through build arguments".

To avoid committing local changes to the compose file into git I also moved it to docker-compose.yml-example and added it to .gitignore.