### PR TITLE
set password of default user through a build argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,11 +83,13 @@ RUN mkdir /var/run/dbus && \
 
 # Add sample user
 # sample user uses uid 999 to reduce conflicts with user ids when mounting an existing home dir
-ARG PASSWORD=ubuntu
-ENV PASSWORD=${PASSWORD}
+# the below has represents the password 'ubuntu'
+# run `openssl passwd -1 'newpassword'` to create a custom hash
+ARG PASSWORDHASH="$1$1osxf5dX$z2IN8cgmQocDYwTCkyh6r/"
+ENV PASSWORDHASH=${PASSWORDHASH}
 RUN addgroup --gid 999 ubuntu && \
   useradd -m -u 999 -s /bin/bash -g ubuntu ubuntu && \
-  echo "ubuntu:${PASSWORD}" | /usr/sbin/chpasswd && \
+  echo "ubuntu:${PASSWORD}" | /usr/sbin/chpasswd -e && \
   echo "ubuntu    ALL=(ALL) ALL" >> /etc/sudoers && \
   unset $PASSWORD
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,10 +83,13 @@ RUN mkdir /var/run/dbus && \
 
 # Add sample user
 # sample user uses uid 999 to reduce conflicts with user ids when mounting an existing home dir
+ARG PASSWORD=ubuntu
+ENV PASSWORD=${PASSWORD}
 RUN addgroup --gid 999 ubuntu && \
   useradd -m -u 999 -s /bin/bash -g ubuntu ubuntu && \
-  echo "ubuntu:ubuntu" | /usr/sbin/chpasswd && \
-  echo "ubuntu    ALL=(ALL) ALL" >> /etc/sudoers
+  echo "ubuntu:${PASSWORD}" | /usr/sbin/chpasswd && \
+  echo "ubuntu    ALL=(ALL) ALL" >> /etc/sudoers && \
+  unset $PASSWORD
 
 # Docker config
 VOLUME ["/etc/ssh","/home"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,9 +89,9 @@ ARG PASSWORDHASH="$1$1osxf5dX$z2IN8cgmQocDYwTCkyh6r/"
 ENV PASSWORDHASH=${PASSWORDHASH}
 RUN addgroup --gid 999 ubuntu && \
   useradd -m -u 999 -s /bin/bash -g ubuntu ubuntu && \
-  echo "ubuntu:${PASSWORD}" | /usr/sbin/chpasswd -e && \
+  echo "ubuntu:${PASSWORDHASH}" | /usr/sbin/chpasswd -e && \
   echo "ubuntu    ALL=(ALL) ALL" >> /etc/sudoers && \
-  unset $PASSWORD
+  unset PASSWORDHASH
 
 # Docker config
 VOLUME ["/etc/ssh","/home"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   terminalserver:
     build:
       context: .
+      args:
+        PASSWORDHASH: "$1$z53Cg/fV$06o379IvIOxj/ESruVKrG1"
     image: danielguerra/ubuntu-xrdp
     container_name: uxrdp
     hostname: terminalserver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        PASSWORDHASH: "$1$z53Cg/fV$06o379IvIOxj/ESruVKrG1"
+        PASSWORDHASH: $$1$$z53Cg/fV$$06o379IvIOxj/ESruVKrG1
     image: danielguerra/ubuntu-xrdp
     container_name: uxrdp
     hostname: terminalserver


### PR DESCRIPTION
I could not let it go and implemented it myself. In docker-compose you could use it like the following (I did not change the bundled compose file to prevent merge conflicts):

```
version: '2.1'
services:
  terminalserver:
    build:
      context: .
      args:
        PASSWORD: my-password
[...]
```

fixes https://github.com/danielguerra69/ubuntu-xrdp/issues/11