### PR TITLE
Make it possible to add additional packages at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 data/
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN mkdir -p /tmp/so
 RUN cp *.so /tmp/so
 
 FROM ubuntu:18.04
+ARG ADDITIONAL_PACKAGES=""
+ENV ADDITIONAL_PACKAGES=${ADDITIONAL_PACKAGES}
+
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt update && apt -y full-upgrade && apt install -y \
   ca-certificates \
@@ -61,6 +64,7 @@ RUN apt update && apt -y full-upgrade && apt install -y \
   xorgxrdp \
   xprintidle \
   xrdp \
+  $ADDITIONAL_PACKAGES \
   && \
   rm -rf /var/cache/apt /var/lib/apt/lists && \
   mkdir -p /var/lib/xrdp-pulseaudio-installer

--- a/Readme.md
+++ b/Readme.md
@@ -87,14 +87,22 @@ This image uses two volumes:
 2. `/home/` holds the `ubuntu/` default user home directory
 
 When bind-mounting `/home/`, make sure it contains a folder `ubuntu/` with proper permission, otherwise no login will be possible.
+
 ```
 mkdir -p ubuntu
 chown 999:999 ubuntu
 ```
 
+## Installing additional packages during build
+
+The Dockerfile has support for the build argument ADDITIONAL_PACKAGES to install additional packages during build. Either pass it with `--build-arg` during `docker build` or add it 
+as `args` in your `docker-compose.override.yml` and run `docker-compose build`.
+
 ## To run with docker-compose
+
 ```bash
 git clone https://github.com/danielguerra69/ubuntu-xrdp.git
 cd ubuntu-xrdp/
+vi docker-compose.override.yml # if you want to override any default value
 docker-compose up -d
 ```


### PR DESCRIPTION
Hi @danielguerra69,

you closed #10 without any further comment. Since I just needed this feature again I though I make another try at it.

add docker-compose.override.yml
to gitignore to easily override default values from the compose file

install custom packages through build arguments (defined through docker-compose or build-args)
add custom packages to readme