### PR TITLE
wip: generate keys for using tls encrypted rdp sessions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ ENV ADDITIONAL_PACKAGES=${ADDITIONAL_PACKAGES}
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt update && apt -y full-upgrade && apt install -y \
   ca-certificates \
+  crudini \
   firefox \
   less \
   locales \

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -53,6 +53,18 @@ if [ ! -f "/etc/xrdp/rsakeys.ini" ];
 		xrdp-keygen xrdp auto
 fi
 
+# generate certificate for tls connection
+if [ ! -f "/etc/xrdp/cert.pem" ];
+	then
+		# delete eventual leftover private key
+		rm -f /etc/xrdp/key.pem || true
+		# TODO make data in certificate configurable?
+		openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365 \
+		-subj "/C=US/ST=Some State/L=Some City/O=Some Org/OU=Some Unit/CN=Terminalserver"
+		crudini --set /etc/xrdp/xrdp.ini Globals certificate /etc/xrdp/cert.pem
+		crudini --set /etc/xrdp/xrdp.ini Globals key_file /etc/xrdp/key.pem
+fi
+
 # generate machine-id
 uuidgen > /etc/machine-id
 


### PR DESCRIPTION
While playing around with Guacamole I noticed that rdp connections from this image seem to be plain text (this is at least what guacamole is saying, i have not found a real way to confirm this). 

As a proof of concept I have extended the startup script to create ssl keys and modify the xrdp.ini with these new keys. but for whatever reason guacamole still says the connection is plain text.

keeping the code here in case someone else has an idea. maybe it'll come to me later as well.