### PR TITLE
generate keys for using tls encrypted rdp sessions

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -58,11 +58,14 @@ if [ ! -f "/etc/xrdp/cert.pem" ];
 	then
 		# delete eventual leftover private key
 		rm -f /etc/xrdp/key.pem || true
+		cd /etc/xrdp
 		# TODO make data in certificate configurable?
 		openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365 \
 		-subj "/C=US/ST=Some State/L=Some City/O=Some Org/OU=Some Unit/CN=Terminalserver"
+		crudini --set /etc/xrdp/xrdp.ini Globals security_layer tls
 		crudini --set /etc/xrdp/xrdp.ini Globals certificate /etc/xrdp/cert.pem
 		crudini --set /etc/xrdp/xrdp.ini Globals key_file /etc/xrdp/key.pem
+
 fi
 
 # generate machine-id


### PR DESCRIPTION
Hi,

Improves upon #21.

I was inspired to look into this today and noticed that the reason I did not work for me was because I create the certificates in the wrong place.

This commit now also enforces tls connections.