### PR TITLE
Set compose file version to 3.5 for shm_size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '3.5'
 services:
   terminalserver:
     build: ./


### PR DESCRIPTION
shm_size was added in version 3.5 file format (https://docs.docker.com/compose/compose-file/#shm_size).

Require Docker Engine version 17.12.0 and higher.