### PR TITLE
WIP: update to latest xrdp releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM ubuntu:18.04 as base
 LABEL maintainer="Daniel Guerra"
 
 # Versions
-ARG XRDP_VER="0.9.10"
+ARG XRDP_VER="0.9.11"
 ENV XRDP_VER=${XRDP_VER}
-ARG XORGXRDP_VER="0.2.10"
+ARG XORGXRDP_VER="0.2.11"
 ENV XORGXRDP_VER=${XORGXRDP_VER}
-ARG XRDPPULSE_VER="0.3"
+ARG XRDPPULSE_VER="0.4"
 ENV XRDPPULSE_VER=${XRDPPULSE_VER}
 
 FROM base as builder
@@ -24,6 +24,7 @@ RUN apt update && apt -y full-upgrade && apt install -y sudo apt-utils software-
 # Build xrdp
 
 WORKDIR /tmp
+RUN groupadd -g 10000 xrdp
 RUN apt build-dep -y xrdp
 RUN wget https://github.com/neutrinolabs/xrdp/releases/download/v"${XRDP_VER}"/xrdp-"${XRDP_VER}".tar.gz
 RUN tar -zxf xrdp-"${XRDP_VER}".tar.gz

--- a/xrdp/debian/patches/series
+++ b/xrdp/debian/patches/series
@@ -1,7 +1,7 @@
 make-fixes.diff
 config.diff
 fix_perms.diff
-shutup-daemon.diff
+#shutup-daemon.diff
 systemd.diff
 lfs.diff
 pulse-debian.patch


### PR DESCRIPTION
I noticed there have been updates to xrdp and its modules.

I tried building it locally (and also fixing my build error from https://github.com/danielguerra69/ubuntu-xrdp/pull/26) but for me the build fails.

wanted to push by changes here so others can maybe pick up from where i left (or give ideas on how to fix).

compile error:
```
find debian/xrdp/usr/lib/ -name \*.a -print0 | \
    xargs -0 strip --strip-debug -R .comment --
make[1]: Leaving directory '/tmp/xrdp-0.9.11'
   dh_install
dh_install: debian/xrdp.install (executable config) returned exit code 1
debian/rules:41: recipe for target 'binary' failed
make: *** [binary] Error 1
dpkg-buildpackage: error: fakeroot debian/rules binary subprocess returned exit status 2
ERROR: Service 'terminalserver' failed to build: The command '/bin/sh -c dpkg-buildpackage -r
fakeroot -uc -b' returned a non-zero code: 2
```