### PR TITLE
Create multiple users in docker-entrypoint

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,9 @@ Use the Xorg session (leave as it is), user and pass.
 To automate the creation of users, supply a file users.list in the /etc directory of the container.
 The format is as follows:
 
+```bash
 id username password-hash list-of-supplemental-groups
+```
 
 The provided users.list file will create a sample user with sudo rights
 

--- a/Readme.md
+++ b/Readme.md
@@ -26,26 +26,28 @@ docker run -d --name uxrdp --hostname terminalserver --shm-size 1g -p 3389:3389 
 Connect with your remote desktop client to the docker server.
 Use the Xorg session (leave as it is), user and pass.
 
-## Sample user
+## Creation of users
 
-There is a sample user with sudo rights
+To automate the creation of users, supply a file users.list in the /etc directory of the container.
+The format is as follows:
+
+id username password-hash list-of-supplemental-groups
+
+The provided users.list file will create a sample user with sudo rights
 
 Username: ubuntu
 Password: ubuntu
 
-
-You can set a PASSWORDHASH
-
-First create a password hash
+To generate the password hash use the following line
 
 ```bash
 openssl passwd -1 'newpassword'
 ```
 
-Run the xrdp container with your hash
+Run the xrdp container with your file
 
 ```bash
-docker run -d -e PASSWORDHASH='$1$Cm8EQjXg$7dJeRsw6TLvgxsl3.pBRZ1'
+docker run -d -v $PWD/users.list:/etc/users.list
 ```
 
 You can change your password in the rdp session in a terminal

--- a/bin/create-users.sh
+++ b/bin/create-users.sh
@@ -3,7 +3,8 @@
 test -f /etc/users.list || exit 0
 
 while read id username hash groups; do
-        grep $username /etc/passwd && continue
+        # Skip, if user already exists
+        grep ^$username /etc/passwd && continue
         # Create group
         addgroup --gid $id $username
         # Create user

--- a/bin/create-users.sh
+++ b/bin/create-users.sh
@@ -12,5 +12,5 @@ while read id username hash groups; do
         # Set password
         echo "$username:$hash" | /usr/sbin/chpasswd -e
         # Add supplemental groups
-        usermod -a -G $groups $username
+        usermod -aG $groups $username
 done < /etc/users.list

--- a/bin/create-users.sh
+++ b/bin/create-users.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+test -f /etc/users.list || exit 0
+
+while read id username hash groups; do
+        grep $username /etc/passwd && continue
+        # Create group
+        addgroup --gid $id $username
+        # Create user
+        useradd -m -u $id -s /bin/bash -g $username $username
+        # Set password
+        echo "$username:$hash" | /usr/sbin/chpasswd -e
+        # Add supplemental groups
+        usermod -a -G $groups $username
+done < /etc/users.list

--- a/bin/create-users.sh
+++ b/bin/create-users.sh
@@ -12,5 +12,7 @@ while read id username hash groups; do
         # Set password
         echo "$username:$hash" | /usr/sbin/chpasswd -e
         # Add supplemental groups
-        usermod -aG $groups $username
+        if [ $groups ]; then
+                usermod -aG $groups $username
+        fi
 done < /etc/users.list

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -48,9 +48,10 @@ if [ ! -f "/etc/xrdp/cert.pem" ];
 		# delete eventual leftover private key
 		rm -f /etc/xrdp/key.pem || true
 		cd /etc/xrdp
-		# TODO make data in certificate configurable?
-		openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365 \
-		-subj "/C=US/ST=Some State/L=Some City/O=Some Org/OU=Some Unit/CN=Terminalserver"
+		if [ ! $CERTIFICATE_SUBJECT ]; then
+			$CERTIFICATE_SUBJECT="/C=US/ST=Some State/L=Some City/O=Some Org/OU=Some Unit/CN=Terminalserver"
+		fi
+		openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365 -subj $CERTIFICATE_SUBJECT
 		crudini --set /etc/xrdp/xrdp.ini Globals security_layer tls
 		crudini --set /etc/xrdp/xrdp.ini Globals certificate /etc/xrdp/cert.pem
 		crudini --set /etc/xrdp/xrdp.ini Globals key_file /etc/xrdp/key.pem

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,18 +1,7 @@
 #!/bin/bash
 
-# Add sample user
-# sample user uses uid 999 to reduce conflicts with user ids when mounting an existing home dir
-# the below has represents the password 'ubuntu'
-# run `openssl passwd -1 'newpassword'` to create a custom hash
-if [ ! $PASSWORDHASH ]; then
-    export PASSWORDHASH='$1$1osxf5dX$z2IN8cgmQocDYwTCkyh6r/'
-fi
-
-addgroup --gid 999 ubuntu && \
-useradd -m -u 999 -s /bin/bash -g ubuntu ubuntu
-echo "ubuntu:$PASSWORDHASH" | /usr/sbin/chpasswd -e
-echo "ubuntu    ALL=(ALL) ALL" >> /etc/sudoers
-unset PASSWORDHASH
+# Add users
+bash /usr/bin/create-users.sh
 
 # Add the ssh config if needed
 

--- a/users.list
+++ b/users.list
@@ -1,0 +1,1 @@
+999 ubuntu $1$Cm8EQjXg$7dJeRsw6TLvgxsl3.pBRZ1 sudo


### PR DESCRIPTION
I adapted the docker-entrypoint.sh to allow for multiple users to be created at container start, including custom userids and a list of supplemental groups to be supplied.
Furthermore I tackled the "Allow certificate subject to be customized" todo from the same file.