### PR TITLE
Adding back $ADDITIONAL_PACKAGES for apt install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,8 @@ RUN apt -y full-upgrade && apt-get install -y \
   xfce4-xkb-plugin \
   xorgxrdp \
   xprintidle \
-  xrdp && \
+  xrdp \
+  $ADDITIONAL_PACKAGES && \
   apt remove -y light-locker xscreensaver && \
   apt autoremove -y && \
   rm -rf /var/cache/apt /var/lib/apt/lists && \


### PR DESCRIPTION
Hi! In the 20.04 branch $ADDITIONAL_PACKAGES is missing as attribute for apt-get install
Would be great if it could be added. Thanks!